### PR TITLE
Support for binding solitary events via the `one` method.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+.DS_Store

--- a/README.md
+++ b/README.md
@@ -56,6 +56,17 @@ And you will see this output:
     notified date Tue, 22 Mar 2011 14:43:41 GMT
     notified date Tue, 22 Mar 2011 14:43:42 GMT
     ...
+    
+You can also bind events via the `one()` method. Events bound in this manner will be called at most once and the automatically discarded.
+
+```javascript
+ticker.one('herp', function(data) {
+	console.log('derp', data);
+});
+
+ticker.trigger('herp'); // Callback is fired.
+ticker.trigger('herp'); // Callback is not fired.
+```
 
 ## Conclusion
 

--- a/examples/example.html
+++ b/examples/example.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html>
-<html> 
-<head></head> 
+<html>
+<head></head>
 <body>
 	<script src="../microevent.js"></script>
 	<script>
@@ -17,7 +17,7 @@
 		* make Ticker support MicroEventjs
 		*/
 		MicroEvent.mixin(Ticker);
-		
+
 		// create a ticker
 		var ticker = new Ticker();
 		// bind the 'tick' event
@@ -25,6 +25,14 @@
 			// display to check
 			console.log('notified data'+ date);
 		});
+
+		ticker.one('herp', function(data) {
+		    console.log('derp', data);
+		});
+
+		ticker.trigger('herp', 'blurp'); // Callback is fired.
+		ticker.trigger('herp', 'blurp'); // Callback is not fired.
+
 	</script>
-</body> 
-</html> 
+</body>
+</html>

--- a/microevent-debug.js
+++ b/microevent-debug.js
@@ -7,23 +7,43 @@
 var MicroEvent	= function(){}
 MicroEvent.prototype	= {
 	bind	: function(event, fct){
-		this._events = this._events || {};		
+        this._events = this._events || {};
+        this._oneEvents = this._oneEvents || {};
 		this._events[event] = this._events[event]	|| [];
 		this._events[event].push(fct);
 	},
+	one     : function(event, fct) {
+        this._events = this._events || {};
+        this._oneEvents = this._oneEvents || {};
+		this._oneEvents[event] = this._oneEvents[event]	|| [];
+		this._oneEvents[event].push(fct);
+	},
 	unbind	: function(event, fct){
 		console.assert(typeof fct === 'function');
-		this._events = this._events || {};		
-		if( event in this._events === false  )	return;
-		console.assert(this._events[event].indexOf(fct) !== -1);
-		this._events[event].splice(this._events[event].indexOf(fct), 1);
+        this._events = this._events || {};
+        this._oneEvents = this._oneEvents || {};
+		if (event in this._events !== false) {
+            console.assert(this._events[event].indexOf(fct) !== -1);
+            this._events[event].splice(this._events[event].indexOf(fct), 1);
+		}
+		if (event in this._oneEvents !== false) {
+            this._oneEvents[event].pop();
+		}
 	},
 	trigger	: function(event /* , args... */){
-		this._events = this._events || {};		
-		if( event in this._events === false  )	return;
-		for(var i = 0; i < this._events[event].length; i++){
-			this._events[event][i].apply(this, Array.prototype.slice.call(arguments, 1))
+        this._events = this._events || {};
+        this._oneEvents = this._oneEvents || {};
+		if (event in this._events !== false) {
+            for (var i = 0; i < this._events[event].length; i++) {
+                this._events[event][i].apply(this, Array.prototype.slice.call(arguments, 1))
+            }
 		}
+		if (this._oneEvents[event] && this._oneEvents[event].length) {
+            for (var i = 0; i < this._oneEvents[event].length; i++){
+                this._oneEvents[event][i].apply(this, Array.prototype.slice.call(arguments, 1));
+                this.unbind(event);
+            }
+        }
 	}
 };
 
@@ -35,7 +55,7 @@ MicroEvent.prototype	= {
  * @param {Object} the object which will support MicroEvent
 */
 MicroEvent.mixin	= function(destObject){
-	var props	= ['bind', 'unbind', 'trigger'];
+	var props	= ['bind', 'unbind', 'trigger', 'one'];
 	for(var i = 0; i < props.length; i ++){
 		if( typeof destObject === 'function' ){
 			destObject.prototype[props[i]]	= MicroEvent.prototype[props[i]];

--- a/microevent.js
+++ b/microevent.js
@@ -9,29 +9,66 @@
  *   - make it safer to use
 */
 
-var MicroEvent	= function(){};
-MicroEvent.prototype	= {
-	bind	: function(event, fct){
-		this._events = this._events || {};
+/**
+ * @class MicroEvent
+ */
+var MicroEvent = function() {
+};
+
+MicroEvent.prototype = {
+    /**
+     * Binds an event until a corresponding call to `unbind` is called.
+     */
+	bind	: function(event, fct) {
+        this._events = this._events || {};
+        this._oneEvents = this._oneEvents || {};
 		this._events[event] = this._events[event]	|| [];
 		this._events[event].push(fct);
 	},
-	unbind	: function(event, fct){
-		this._events = this._events || {};
-		if( event in this._events === false  )	return;
-		var indexOfFunc = this._events[event].indexOf(fct);
-		if(indexOfFunc !== -1) {
-			this._events[event].splice(indexOfFunc, 1);
-		} else {
-			this._events[event] = [];
+	/**
+	 * Binds an event that is then unbound after the first call.
+	 */
+	one     : function(event, fct) {
+        this._events = this._events || {};
+        this._oneEvents = this._oneEvents || {};
+		this._oneEvents[event] = this._oneEvents[event]	|| [];
+		this._oneEvents[event].push(fct);
+	},
+	/**
+	 * Unbinds an event.
+	 */
+	unbind	: function(event, fct) {
+        this._events = this._events || {};
+        this._oneEvents = this._oneEvents || {};
+		if (event in this._events !== false) {
+            var indexOfFunc = this._events[event].indexOf(fct);
+            if (indexOfFunc !== -1) {
+                this._events[event].splice(indexOfFunc, 1);
+            } else {
+                this._events[event] = [];
+            }
+		}
+		if (event in this._oneEvents !== false) {
+            this._oneEvents[event].pop();
 		}
 	},
-	trigger	: function(event /* , args... */){
-		this._events = this._events || {};
-		if( event in this._events === false  )	return;
-		for(var i = 0; i < this._events[event].length; i++){
-			this._events[event][i].apply(this, Array.prototype.slice.call(arguments, 1));
-		}
+	/**
+	 * Triggers an event.
+	 */
+	trigger	: function(event /* , args... */) {
+        this._events = this._events || {};
+        this._oneEvents = this._oneEvents || {};
+		if (this._events[event] && this._events[event].length) {
+            for (var i = 0; i < this._events[event].length; i++){
+                this._events[event][i].apply(this, Array.prototype.slice.call(arguments, 1));
+            }
+        }
+		if (this._oneEvents[event] && this._oneEvents[event].length) {
+            for (var i = 0; i < this._oneEvents[event].length; i++){
+                this._oneEvents[event][i].apply(this, Array.prototype.slice.call(arguments, 1));
+                this.unbind(event);
+            }
+        }
 	}
 };
 
@@ -43,7 +80,7 @@ MicroEvent.prototype	= {
  * @param {Object} the object which will support MicroEvent
 */
 MicroEvent.mixin	= function(destObject){
-	var props	= ['bind', 'unbind', 'trigger'];
+	var props	= ['bind', 'one', 'unbind', 'trigger'];
 	for(var i = 0; i < props.length; i ++){
 		if( typeof destObject === 'function' ){
 			destObject.prototype[props[i]]	= MicroEvent.prototype[props[i]];


### PR DESCRIPTION
The following PR introduces support for binding events via the `one` method. Events bound in this manner will be called once at most, at which point they are automatically discarded.
